### PR TITLE
MCP Mapping Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gradle plugin to aid in the development of shards.
    - [x] Natives
  - [x] Deobfuscating Minecraft
    - [x] Yarn Mappings (Mostly)
-   - [ ] MCP Mappings
+   - [x] MCP Mappings (Pre-1.13)
    - [x] Mojang Mappings
    - [ ] Sand Mappings? (Custom GlassMC Mappings)
  - [x] Depending On Shards

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'com.github.johnrengelman:shadow:7.0.0'
 
     implementation 'com.github.fabricmc:tiny-mappings-parser:750be4e739'
+    implementation 'org.apache.commons:commons-csv:1.9.0'
 }
 
 publishing {

--- a/src/main/java/com/github/glassmc/kiln/common/Util.java
+++ b/src/main/java/com/github/glassmc/kiln/common/Util.java
@@ -16,7 +16,6 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;

--- a/src/main/java/com/github/glassmc/kiln/standard/DependencyHandlerExtension.java
+++ b/src/main/java/com/github/glassmc/kiln/standard/DependencyHandlerExtension.java
@@ -1,6 +1,7 @@
 package com.github.glassmc.kiln.standard;
 
 import com.github.glassmc.kiln.standard.mappings.IMappingsProvider;
+import com.github.glassmc.kiln.standard.mappings.MCPMappingsProvider;
 import com.github.glassmc.kiln.standard.mappings.MojangMappingsProvider;
 import com.github.glassmc.kiln.common.Util;
 import com.github.glassmc.kiln.standard.mappings.NoSuchMappingsException;
@@ -33,6 +34,9 @@ public class DependencyHandlerExtension {
                 break;
             case "mojang":
                 mappingsProvider = new MojangMappingsProvider();
+                break;
+            case "mcp":
+                mappingsProvider = new MCPMappingsProvider();
                 break;
             case "obfuscated":
             default:

--- a/src/main/java/com/github/glassmc/kiln/standard/mappings/MCPMappingsProvider.java
+++ b/src/main/java/com/github/glassmc/kiln/standard/mappings/MCPMappingsProvider.java
@@ -1,0 +1,193 @@
+package com.github.glassmc.kiln.standard.mappings;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.internal.Pair;
+import org.objectweb.asm.commons.Remapper;
+
+import com.github.glassmc.kiln.standard.remapper.CSRGRemapper;
+import com.github.glassmc.kiln.standard.remapper.CSVRemapper;
+import com.github.glassmc.kiln.standard.remapper.HashRemapper;
+import com.github.glassmc.kiln.standard.remapper.ReversibleRemapper;
+import com.github.glassmc.kiln.standard.remapper.UniqueRemapper;
+
+public class MCPMappingsProvider implements IMappingsProvider {
+
+    private String version;
+    // A map of the most stable MCP mappings for each version.
+    private final Map<String, Pair<String, String>> mappings = new HashMap<String, Pair<String, String>>() {
+        {
+            put("1.7.10", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.7.10/mcp-1.7.10-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/12-1.7.10/mcp_stable-12-1.7.10.zip"
+            ));
+            put("1.8", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.8/mcp-1.8-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/18-1.8/mcp_stable-18-1.8.zip"
+            ));
+            put("1.8.8", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.8.8/mcp-1.8.8-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/20-1.8.8/mcp_stable-20-1.8.8.zip"
+            ));
+            put("1.8.9", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.8.9/mcp-1.8.9-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/22-1.8.9/mcp_stable-22-1.8.9.zip"
+            ));
+            put("1.9", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.9/mcp-1.9-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/24-1.9/mcp_stable-24-1.9.zip"
+            ));
+            put("1.9.2", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.9.2/mcp-1.9.2-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/24-1.9/mcp_stable-24-1.9.zip"
+            ));
+            put("1.9.4", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.9.4/mcp-1.9.4-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/26-1.9.4/mcp_stable-26-1.9.4.zip"
+            ));
+            put("1.10", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.10/mcp-1.10-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/29-1.10.2/mcp_stable-29-1.10.2.zip"
+            ));
+            put("1.10.2", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.10.2/mcp-1.10.2-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/29-1.10.2/mcp_stable-29-1.10.2.zip"
+            ));
+            put("1.11", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.11/mcp-1.11-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/32-1.11/mcp_stable-32-1.11.zip"
+            ));
+            put("1.11.1", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.11.1/mcp-1.11.1-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/32-1.11/mcp_stable-32-1.11.zip"
+            ));
+            put("1.11.2", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.11.2/mcp-1.11.2-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/32-1.11/mcp_stable-32-1.11.zip"
+            ));
+            put("1.12", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.12/mcp-1.12-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/39-1.12/mcp_stable-39-1.12.zip"
+            ));
+            put("1.12.1", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.12.1/mcp-1.12.1-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/39-1.12/mcp_stable-39-1.12.zip"
+            ));
+            put("1.12.2", Pair.of(
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.12.2/mcp-1.12.2-csrg.zip",
+                    "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_stable/39-1.12/mcp_stable-39-1.12.zip"
+            ));
+        }
+    };
+
+    private HashRemapper searge;
+    private ReversibleRemapper reversedSearge;
+    private UniqueRemapper named;
+    private ReversibleRemapper reversedNamed;
+
+    @Override
+    public void setup(File minecraftFile, String version) throws NoSuchMappingsException {
+        this.version = version;
+
+        File temp = new File(minecraftFile, "temp");
+        Pair<String, String> mappingURLs = mappings.get(version);
+
+        if(mappingURLs == null) {
+            throw new NoSuchMappingsException(version);
+        }
+
+        URL seargeURL;
+        URL namedURL;
+
+        try {
+            seargeURL = new URL(Objects.requireNonNull(mappingURLs.getLeft()));
+            namedURL = new URL(Objects.requireNonNull(mappingURLs.getRight()));
+        } catch(MalformedURLException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        try {
+            String seargeFileBase = seargeURL.getFile().substring(seargeURL.getFile().lastIndexOf("/")).substring(1)
+                    .replace(".zip", "");
+            String namedFileBase = namedURL.getFile().substring(namedURL.getFile().lastIndexOf("/")).substring(1)
+                    .replace(".zip", "");
+
+            File seargeMappings = new File(temp, seargeFileBase + "-joined.csrg");
+            File fieldMappings = new File(temp, namedFileBase + "-fields.csv");
+            File methodMappings = new File(temp, namedFileBase + "-methods.csv");
+
+            if(!seargeMappings.exists() || !fieldMappings.exists()) {
+                File seargeMappingsFile = new File(temp, seargeFileBase + ".zip");
+                File namedMappingsFile = new File(temp, namedFileBase + ".zip");
+                FileUtils.copyURLToFile(namedURL, namedMappingsFile);
+                FileUtils.copyURLToFile(seargeURL, seargeMappingsFile);
+
+                ZipFile seargeZIPFile = new ZipFile(seargeMappingsFile);
+                FileUtils.copyInputStreamToFile(seargeZIPFile.getInputStream(new ZipEntry("joined.csrg")),
+                        seargeMappings);
+                seargeZIPFile.close();
+
+                JarFile namedJARFile = new JarFile(namedMappingsFile);
+                FileUtils.copyInputStreamToFile(namedJARFile.getInputStream(new ZipEntry("fields.csv")), fieldMappings);
+                FileUtils.copyInputStreamToFile(namedJARFile.getInputStream(new ZipEntry("methods.csv")),
+                        methodMappings);
+                namedJARFile.close();
+            }
+
+            searge = CSRGRemapper.create(seargeMappings);
+            reversedSearge = searge.reversed();
+            named = CSVRemapper.create(null, fieldMappings, methodMappings, "searge", "name");
+            reversedNamed = named.toNonUnique(searge).reversed();
+        } catch(IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Remapper getRemapper(Direction direction) {
+        Remapper initial = direction == Direction.TO_NAMED ? searge : reversedNamed;
+        Remapper result = direction == Direction.TO_NAMED ? named : reversedSearge;
+
+        return new Remapper() {
+
+            @Override
+            public String map(String name) {
+                return result.map(initial.map(name));
+            }
+
+            @Override
+            public String mapMethodName(String owner, String name, String descriptor) {
+                return result.mapMethodName(initial.map(owner), initial.mapMethodName(owner, name, descriptor),
+                        initial.mapDesc(descriptor));
+            }
+
+            @Override
+            public String mapFieldName(String owner, String name, String descriptor) {
+                return result.mapFieldName(initial.map(owner), initial.mapFieldName(owner, name, descriptor), "");
+            }
+
+        };
+    }
+
+    @Override
+    public String getID() {
+        return "mcp";
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+}

--- a/src/main/java/com/github/glassmc/kiln/standard/mappings/MojangMappingsProvider.java
+++ b/src/main/java/com/github/glassmc/kiln/standard/mappings/MojangMappingsProvider.java
@@ -11,12 +11,13 @@ import org.objectweb.asm.commons.Remapper;
 import com.github.glassmc.kiln.common.Util;
 import com.github.glassmc.kiln.standard.remapper.HashRemapper;
 import com.github.glassmc.kiln.standard.remapper.ProGuardRemapper;
+import com.github.glassmc.kiln.standard.remapper.ReversibleRemapper;
 
 public class MojangMappingsProvider implements IMappingsProvider {
 
     private String version;
-    private HashRemapper deobfuscator;
-    private HashRemapper obfuscator;
+    private ReversibleRemapper deobfuscator;
+    private ReversibleRemapper obfuscator;
 
     @Override
     public void setup(File minecraftFile, String version) throws NoSuchMappingsException {

--- a/src/main/java/com/github/glassmc/kiln/standard/remapper/CSRGRemapper.java
+++ b/src/main/java/com/github/glassmc/kiln/standard/remapper/CSRGRemapper.java
@@ -1,0 +1,57 @@
+package com.github.glassmc.kiln.standard.remapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.fabricmc.mapping.util.EntryTriple;
+
+public class CSRGRemapper {
+
+    public static HashRemapper create(File file) throws IOException {
+        Map<String, String> classNames = new HashMap<>();
+        Map<EntryTriple, String> fieldNames = new HashMap<>();
+        Map<EntryTriple, String> methodNames = new HashMap<>();
+
+        int lineNumber = 1;
+
+        for(String line : Files.readAllLines(file.toPath())) {
+            if(line.startsWith(".")) {
+                continue;
+            }
+
+            String[] columns = line.split(" ");
+
+            if(columns.length == 2) {
+                String srcName = columns[0];
+                String dstName = columns[1];
+
+                if(srcName.endsWith("/")) {
+                    continue; // Skip packages.
+                }
+
+                classNames.put(srcName, dstName);
+            } else if(columns.length == 3) {
+                String srcOwner = columns[0];
+                String srcName = columns[1];
+                String dstName = columns[2];
+
+                fieldNames.put(new EntryTriple(srcOwner, srcName, ""), dstName);
+            } else if(columns.length == 4) {
+                String srcOwner = columns[0];
+                String srcName = columns[1];
+                String srcDesc = columns[2];
+                String dstName = columns[3];
+
+                methodNames.put(new EntryTriple(srcOwner, srcName, srcDesc), dstName);
+            } else {
+                throw new MappingParseException(columns.length + " columns unsupported", lineNumber);
+            }
+        }
+
+        return new HashRemapper(classNames, fieldNames, methodNames);
+    }
+
+}

--- a/src/main/java/com/github/glassmc/kiln/standard/remapper/CSVRemapper.java
+++ b/src/main/java/com/github/glassmc/kiln/standard/remapper/CSVRemapper.java
@@ -1,0 +1,46 @@
+package com.github.glassmc.kiln.standard.remapper;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+
+public class CSVRemapper {
+
+    public static UniqueRemapper create(File classesFile, File fieldsFile, File methodsFile, String srcColumn, String dstColumn) throws IOException {
+        Map<String, String> classNames = new HashMap<>();
+        Map<String, String> fieldNames = new HashMap<>();
+        Map<String, String> methodNames = new HashMap<>();
+
+        if(classesFile != null) {
+            classNames = toMap(classesFile, srcColumn, dstColumn);
+        }
+        if(fieldsFile != null) {
+            fieldNames = toMap(fieldsFile, srcColumn, dstColumn);
+        }
+        if(methodsFile != null) {
+            methodNames = toMap(methodsFile, srcColumn, dstColumn);
+        }
+
+        return new UniqueRemapper(classNames, fieldNames, methodNames);
+    }
+
+    private static Map<String, String> toMap(File file, String srcColumn, String dstColumn) throws IOException {
+        Map<String, String> result = new HashMap<>();
+
+        FileReader reader = new FileReader(file);
+
+        Iterable<CSVRecord> records = CSVFormat.Builder.create().setHeader().build().parse(reader);
+
+        for(CSVRecord record : records) {
+            result.put(record.get(srcColumn), record.get(dstColumn));
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/github/glassmc/kiln/standard/remapper/ReversibleRemapper.java
+++ b/src/main/java/com/github/glassmc/kiln/standard/remapper/ReversibleRemapper.java
@@ -1,0 +1,9 @@
+package com.github.glassmc.kiln.standard.remapper;
+
+import org.objectweb.asm.commons.Remapper;
+
+public abstract class ReversibleRemapper extends Remapper {
+
+    public abstract ReversibleRemapper reversed();
+
+}

--- a/src/main/java/com/github/glassmc/kiln/standard/remapper/UniqueRemapper.java
+++ b/src/main/java/com/github/glassmc/kiln/standard/remapper/UniqueRemapper.java
@@ -1,0 +1,88 @@
+package com.github.glassmc.kiln.standard.remapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.fabricmc.mapping.util.EntryTriple;
+
+public class UniqueRemapper extends ReversibleRemapper {
+
+    protected Map<String, String> classNames;
+    protected Map<String, String> fieldNames;
+    protected Map<String, String> methodNames;
+
+    public UniqueRemapper() {
+        this(new HashMap<>(), new HashMap<>(), new HashMap<>());
+    }
+
+    public UniqueRemapper(Map<String, String> classNames, Map<String, String> fieldNames,
+            Map<String, String> methodNames) {
+        this.classNames = classNames;
+        this.fieldNames = fieldNames;
+        this.methodNames = methodNames;
+    }
+
+    @Override
+    public String map(String name) {
+        return classNames.getOrDefault(name, name);
+    }
+
+    @Override
+    public String mapFieldName(final String owner, final String name, final String descriptor) {
+        return fieldNames.getOrDefault(name, name);
+    }
+
+    @Override
+    public String mapMethodName(final String owner, final String name, final String descriptor) {
+        return methodNames.getOrDefault(name, name);
+    }
+
+    @Override
+    public UniqueRemapper reversed() {
+        Map<String, String> reverseClassNames = new HashMap<>();
+        Map<String, String> reverseFieldNames = new HashMap<>();
+        Map<String, String> reverseMethodNames = new HashMap<>();
+
+        classNames.forEach((key, value) -> reverseClassNames.put(value, key));
+        fieldNames.forEach((key, value) -> reverseFieldNames.put(value, key));
+        methodNames.forEach((key, value) -> reverseMethodNames.put(value, key));
+
+        return new UniqueRemapper(reverseClassNames, reverseFieldNames, reverseMethodNames);
+    }
+
+    public HashRemapper toNonUnique(HashRemapper from) {
+        Map<EntryTriple, String> fieldNames = new HashMap<>();
+        Map<EntryTriple, String> methodNames = new HashMap<>();
+
+        Map<String, EntryTriple> fromFieldNamesReversed = new HashMap<>();
+        Map<String, EntryTriple> fromMethodNamesReversed = new HashMap<>();
+
+        from.fieldNames.forEach((key, value) -> fromFieldNamesReversed.put(value, key));
+        from.methodNames.forEach((key, value) -> fromMethodNamesReversed.put(value, key));
+
+        this.fieldNames.forEach((key, value) -> {
+            EntryTriple entry = fromFieldNamesReversed.get(key);
+
+            if(entry == null) {
+                return;
+            }
+
+            fieldNames.put(new EntryTriple(from.classNames.get(entry.getOwner()), key,
+                    entry.getDescriptor().isEmpty() ? "" : from.mapDesc(entry.getDescriptor())), value);
+        });
+
+        this.methodNames.forEach((key, value) -> {
+            EntryTriple entry = fromMethodNamesReversed.get(key);
+
+            if(entry == null) {
+                return;
+            }
+
+            methodNames.put(new EntryTriple(from.classNames.get(entry.getOwner()), key, from.mapMethodDesc(entry.getDescriptor())),
+                    value);
+        });
+
+        return new HashRemapper(classNames, fieldNames, methodNames);
+    }
+
+}


### PR DESCRIPTION
Adds support for Mod Coder Pack mappings. Currently only works with legacy (pre-1.13) Minecraft versions.

I don't really see much of a point of adding newer versions, since MCP was (seemingly) discontinued in 1.17.

Later versions could be added pretty easily, it just needs a TSRG parser along with the existing CSRG parser (yeah, I know, MCP is confusing).

Sorry for the extra library, but the most of the CSV entries use double quotes. At least it isn't LibHelloWorld or something.

```java
import com.github.stupidlibs.libhelloworld.*;
import com.github.stupidlibs.libhelloworld.builder.*;
import com.github.stupidlibs.libhelloworld.factory.*;
import com.github.stupidlibs.libhelloworld.misc.*;
import com.github.stupidlibs.libhelloworld.completelyunnecessaryclasses.*;

/**
 * My first program.
 * @since 1.0
 * @author Me
 */
public class Main {

    public static void main(String[] args) {
		Logger.builder(Level.STUPIDLY_UNIMPORTANT).build()
			.unimportant(Greeting.builder(GreetingString.builder())
				.type(DefaultGreetingCategories.INFORMAL)
				.difficulty(GreetingDifficulty.NOOB)
				.greetingRepresentationFactoryClass(DefaultGreetingRepresentationFactoryClass.class)
				.greetingRepresentationFactoryClassName(DefaultGreetingRepresentationFactoryClass.class.getName())
				.defaultRepresentation(GreetingRepresentations.STRING)
				.value(DefaultLanguages.English.INSTANCE.checkWord(EveryPossibleAsciiWord.HELLO).append(Whitespace.SPACE).append(DefaultLanguages.English.INSTANCE.checkWord(Ascii.Words.EveryPossibleAsciiWord.WORLD)).append(Ascii.Punctiation.EXCLAIMATION_MARK))
				.build().as(GreetingRepresentations.STRING));
    }

}
```